### PR TITLE
[PR #3 follow-up] Reset in-tab admin auth on user logout

### DIFF
--- a/frontend/js/admin.js
+++ b/frontend/js/admin.js
@@ -46,9 +46,7 @@ const AdminView = (() => {
     }
 
     function handleLogout() {
-        isAuthenticated = false;
-        document.getElementById('admin-login-section').classList.remove('hidden');
-        document.getElementById('admin-content-section').classList.add('hidden');
+        resetAuth();
     }
 
     function renderAdminContent() {
@@ -365,13 +363,21 @@ const AdminView = (() => {
         return text.replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
     }
 
+    function resetAuth() {
+        isAuthenticated = false;
+        document.getElementById('admin-pin-input').value = '';
+        document.getElementById('admin-login-error').textContent = '';
+        document.getElementById('admin-login-section').classList.remove('hidden');
+        document.getElementById('admin-content-section').classList.add('hidden');
+    }
+
     function show() {
         if (isAuthenticated) {
             renderAdminContent();
         }
     }
 
-    return { init, show };
+    return { init, show, resetAuth };
 })();
 
 // Export for Node.js testing

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -123,6 +123,9 @@ const App = (() => {
 
     function handleUserLogout() {
         Store.logoutUser();
+        if (typeof AdminView.resetAuth === 'function') {
+            AdminView.resetAuth();
+        }
         showLoginScreen();
     }
 

--- a/frontend/tests/app.test.js
+++ b/frontend/tests/app.test.js
@@ -7,7 +7,7 @@ window.Store = Store;
 
 globalThis.SnacksView = { init: vi.fn(), render: vi.fn() };
 globalThis.DrinksView = { init: vi.fn(), render: vi.fn() };
-globalThis.AdminView = { init: vi.fn(), show: vi.fn() };
+globalThis.AdminView = { init: vi.fn(), show: vi.fn(), resetAuth: vi.fn() };
 globalThis.ScannerService = { setOnScanCallback: vi.fn() };
 globalThis.ApiService = { getUserInfo: vi.fn() };
 Object.assign(global, {
@@ -133,6 +133,7 @@ describe('App', () => {
 
         document.getElementById('user-logout-btn').click();
         expect(Store.getCurrentUser()).toBeNull();
+        expect(AdminView.resetAuth).toHaveBeenCalledTimes(1);
         expect(document.getElementById('user-login-screen').classList.contains('hidden')).toBe(false);
     });
 


### PR DESCRIPTION
### Motivation
- Prevent a privilege-escalation where AdminView's in-memory authenticated state persists across consecutive users in the same browser tab so the next user could access admin without re-entering the PIN.

### Description
- Add `AdminView.resetAuth()` which clears the in-memory `isAuthenticated` flag, clears the PIN input and login error, and forces the admin UI back to the locked/login section.
- Call `AdminView.resetAuth()` from `App.handleUserLogout()` so logout clears both the user session and any unlocked admin state in the same tab.
- Refactor `admin.js` so `handleLogout()` delegates to `resetAuth()` and export `resetAuth` as part of the `AdminView` API for testability.
- Update `frontend/tests/app.test.js` to include a `resetAuth` mock on `AdminView` and assert it is invoked when a user logs out.

### Testing
- Ran `cd frontend && npm test -- --run tests/app.test.js tests/admin.test.js` and both test files passed (2 files, 16 tests total passed).
- Unit tests assert `AdminView.resetAuth()` is called on user logout and existing admin-related tests continue to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef1afc54b48333a745ec71db3d587f)