### PR TITLE
fix(frontend): improve product button contrast

### DIFF
--- a/local/static_mock/admin.html
+++ b/local/static_mock/admin.html
@@ -178,7 +178,7 @@ body {
 
 .product-card__button {
     background: rgba(56, 189, 248, 0.18);
-    color: var(--accent-contrast);
+    color: var(--text-primary);
     border: 1px dashed rgba(56, 189, 248, 0.5);
     border-radius: 0.75rem;
     padding: 0.75rem;

--- a/local/static_mock/drinks.html
+++ b/local/static_mock/drinks.html
@@ -178,7 +178,7 @@ body {
 
 .product-card__button {
     background: rgba(56, 189, 248, 0.18);
-    color: var(--accent-contrast);
+    color: var(--text-primary);
     border: 1px dashed rgba(56, 189, 248, 0.5);
     border-radius: 0.75rem;
     padding: 0.75rem;

--- a/local/static_mock/index.html
+++ b/local/static_mock/index.html
@@ -178,7 +178,7 @@ body {
 
 .product-card__button {
     background: rgba(56, 189, 248, 0.18);
-    color: var(--accent-contrast);
+    color: var(--text-primary);
     border: 1px dashed rgba(56, 189, 248, 0.5);
     border-radius: 0.75rem;
     padding: 0.75rem;

--- a/local/static_mock/snacks.html
+++ b/local/static_mock/snacks.html
@@ -178,7 +178,7 @@ body {
 
 .product-card__button {
     background: rgba(56, 189, 248, 0.18);
-    color: var(--accent-contrast);
+    color: var(--text-primary);
     border: 1px dashed rgba(56, 189, 248, 0.5);
     border-radius: 0.75rem;
     padding: 0.75rem;

--- a/local/webapp/static/css/app.css
+++ b/local/webapp/static/css/app.css
@@ -170,7 +170,7 @@ body {
 
 .product-card__button {
     background: rgba(56, 189, 248, 0.18);
-    color: var(--accent-contrast);
+    color: var(--text-primary);
     border: 1px dashed rgba(56, 189, 248, 0.5);
     border-radius: 0.75rem;
     padding: 0.75rem;


### PR DESCRIPTION
### Motivation
- Erhöhe die Lesbarkeit der Produkt-Buttons durch besseren Farbkontrast auf halbtransparentem blauem Hintergrund zur Einhaltung der Touch-Display Accessibility-Richtlinie. 
- Halte die statischen Mock-Seiten in `local/static_mock/` synchron mit den Flask-Templates, damit Offline-Mocks visuell konsistent bleiben.

### Description
- Ändere die Textfarbe der CSS-Klasse `.product-card__button` von `var(--accent-contrast)` auf `var(--text-primary)` in `local/webapp/static/css/app.css`.
- Übernehme dieselbe Anpassung in allen statischen Mock-Dateien `local/static_mock/index.html`, `local/static_mock/snacks.html`, `local/static_mock/drinks.html` und `local/static_mock/admin.html` damit Layout und Farben übereinstimmen.
- Keine weiteren Stil- oder Layout-Änderungen wurden vorgenommen, und externe Asset-Imports in den Mocks wurden nicht eingeführt.

### Testing
- Validierung per Dateidiff bestätigte die erwartete Änderung an `local/webapp/static/css/app.css` und allen vier Mock-Dateien und meldete keine unerwarteten Deltas.
- Ein Scan nach `@import` in den Mock- und CSS-Dateien fand keine externen CSS-Importe, sodass die Mocks offline-selbstständig bleiben.
- Visuelle Screenshot-Checks konnten in dieser Umgebung nicht ausgeführt werden; funktionale/automatisierte Prüfungen wie oben verliefen erfolgreich.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef2a10e1a8833380ed76e37b4ab162)