### PR TITLE
Add local orders DB, sales-backend-mode, export endpoints and frontend admin UI

### DIFF
--- a/broker/ORDER_EXPORT.md
+++ b/broker/ORDER_EXPORT.md
@@ -1,0 +1,20 @@
+# Order Export
+
+## Zweck
+Exportiert ausschließlich vom Automaten ausgelöste Bestellungen aus der lokalen SQLite-Datenbank.
+
+## Endpoint
+`GET /export/orders?format=json|csv&from=YYYY-MM-DD&to=YYYY-MM-DD&memberid=...`
+
+## Parameter
+- `format`: `json` oder `csv` (Pflicht, default `json`)
+- `from`: optional, Filter `bookingdate >= from`
+- `to`: optional, Filter `bookingdate <= to`
+- `memberid`: optional, exakter Filter
+
+## Antwort
+- JSON: `application/json`
+- CSV: `text/csv` + Download Header
+
+## Exportierte Felder
+`id, created_at_utc, source, memberid, itemid, articleid, amount, bookingdate, vf_response_json`

--- a/broker/SALES_BACKEND_MODE.md
+++ b/broker/SALES_BACKEND_MODE.md
@@ -1,0 +1,21 @@
+# Sales Backend Mode (Broker)
+
+## Ziel
+Der Broker kann Bestellungen entweder direkt an Vereinsflieger buchen (`vereinsflieger`) oder nur lokal in einer SQLite-Datenbank speichern (`local_db`).
+
+## Modusverwaltung
+- API: `GET /admin/sales-backend-mode`
+- API: `PUT /admin/sales-backend-mode` mit JSON `{ "mode": "vereinsflieger" | "local_db" }`
+- Persistenz in SQLite-Tabelle `settings` (`sales_backend_mode`).
+
+## Verhaltensregeln
+- `vereinsflieger`: bestehender Vereinsflieger-Flow bleibt aktiv und unverändert.
+- `local_db`: keine Vereinsflieger-Buchung; Bestellung wird nur lokal gespeichert.
+- In beiden Modi wird die Bestellung in `orders` protokolliert (Audit/Export).
+
+## Sicherheit
+- Endpunkte sind JWT-geschützt.
+- Ungültige Modi werden mit `400` abgelehnt.
+
+## Datenbank
+Standardpfad: `broker/data/orders.db` (über `ORDER_DB_PATH` überschreibbar).

--- a/broker/main.py
+++ b/broker/main.py
@@ -1,5 +1,5 @@
 import tempfile
-from flask import Flask, request
+from flask import Flask, request, Response
 from flask_jwt_extended import JWTManager, jwt_required
 from flask_talisman import Talisman
 import logging
@@ -15,31 +15,38 @@ Talisman(app)
 @app.route('/getAllProducts', methods=['GET'])
 @jwt_required()
 def get_all_products():
+    """Return all products from the upstream backend."""
     return vf_data.get_shop_items()
 
 @app.route('/getFUProducts', methods=['GET'])
 @jwt_required()
 def get_fu_products():
+    """Return only snack machine products."""
     return vf_data.get_fu_products()
 
 @app.route('/getValidFUProducts', methods=['GET'])
 @jwt_required()
 def get_valid_f_products():
+    """Return snack machine products valid for the current date."""
     return vf_data.get_valid_fu_products()
 
 
 @app.route('/test', methods=['GET'])
 @jwt_required()
 def test():
+    """Return static response used by local health checks."""
     return "Hello World"
 
 @app.route('/Buy', methods=['POST'])
 @jwt_required()
 def test_buy():
-    data = request.get_json()
+    """Validate and register a product purchase."""
+    data = request.get_json(silent=True) or {}
     memberid = data.get('memberid')
     itemid = data.get('itemid')
     amount = data.get('amount')
+    if memberid is None or itemid is None or amount is None:
+        return {"message": "memberid, itemid und amount sind erforderlich"}, 400
     buyer = {
         "memberid": memberid,
     }
@@ -47,28 +54,87 @@ def test_buy():
     # Check if the requested item is in the list of valid items
     valid_item = valid_items.get(itemid)
     if valid_item:
-        response = vf_data.set_new_sale(buyer, amount, valid_item)
+        item_with_id = {**valid_item, "id": itemid}
+        response = vf_data.process_sale(buyer, amount, item_with_id)
+        if response == vf_data.CON_ERROR:
+            return {"message": "Sale booking failed"}, 502
         return response
     else:
         return {"message": "Invalid item"}, 400
 
+
+@app.route('/admin/sales-backend-mode', methods=['GET'])
+@jwt_required()
+def get_sales_backend_mode():
+    """Return currently active sales backend mode."""
+    return {"mode": vf_data.get_sales_backend_mode()}, 200
+
+
+@app.route('/admin/sales-backend-mode', methods=['PUT'])
+@jwt_required()
+def set_sales_backend_mode():
+    """Update sales backend mode ('vereinsflieger' or 'local_db')."""
+    data = request.get_json(silent=True) or {}
+    mode = data.get("mode")
+    if not isinstance(mode, str):
+        return {"message": "mode fehlt oder ist ungültig"}, 400
+    try:
+        normalized_mode = vf_data.set_sales_backend_mode(mode)
+    except ValueError as exc:
+        return {"message": str(exc)}, 400
+    return {"mode": normalized_mode}, 200
+
+
+@app.route('/export/orders', methods=['GET'])
+@jwt_required()
+def export_orders():
+    """Export machine order history from local database as JSON or CSV."""
+    output_format = request.args.get("format", default="json", type=str).lower()
+    from_date = request.args.get("from", type=str)
+    to_date = request.args.get("to", type=str)
+    memberid = request.args.get("memberid", type=str)
+
+    try:
+        content, mimetype = vf_data.export_orders(
+            output_format=output_format,
+            from_date=from_date,
+            to_date=to_date,
+            memberid=memberid,
+        )
+    except ValueError as exc:
+        return {"message": str(exc)}, 400
+
+    if mimetype == "text/csv":
+        return Response(
+            content,
+            mimetype=mimetype,
+            headers={"Content-Disposition": "attachment; filename=orders_export.csv"},
+        )
+    return Response(content, mimetype=mimetype)
+
 @app.route('/getUserInfo', methods=['POST'])
 @jwt_required()
 def get_user_info():
-    data = request.get_json()
+    """Return local user metadata for the provided RFID."""
+    data = request.get_json(silent=True) or {}
     memberid = data.get('rfid_id')
+    if not memberid:
+        return {"message": "rfid_id fehlt"}, 400
     return vf_data.get_user_info(memberid)
 
 @app.route('/getSpecificProduct', methods=['POST'])
 @jwt_required()
 def get_product():
-    data = request.get_json()
+    """Return the first product matching the requested vending row marker."""
+    data = request.get_json(silent=True) or {}
     row = data.get('row')
+    if row is None:
+        return {"message": "row fehlt"}, 400
     valid_products = vf_data.get_valid_fu_products()
     for product_id, product_details in valid_products.items():
         if f'[{row}]' in product_details.get('designation', ''):
             return product_details
-        return "False"
+    return "False"
 
 def ensure_ssl_certificates(cert_filename='data/cert.pem', key_filename='data/key.pem'):
     base_dir = os.path.dirname(os.path.abspath(__file__))
@@ -96,13 +162,9 @@ def ensure_ssl_certificates(cert_filename='data/cert.pem', key_filename='data/ke
     return cert_path, key_path
 
 if __name__ == '__main__':
-    if app.config['FLASK_ENV'] is True:
+    if os.getenv("FLASK_ENV") == "development":
         logging.basicConfig(level=logging.DEBUG)
-    #app.run(debug=True, host="0.0.0.0", port=8123)
         app.run(debug=True, host="0.0.0.0", port=8124, ssl_context=("data/cert.pem","data/key.pem"))
     else:
         logging.basicConfig(level=logging.INFO)
         app.run(debug=False, host="0.0.0.0", port=8124, ssl_context=("data/cert.pem","data/key.pem"))
-
-
-

--- a/broker/orders_db.py
+++ b/broker/orders_db.py
@@ -1,0 +1,180 @@
+"""SQLite persistence for order history and runtime broker settings."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import os
+import sqlite3
+from contextlib import closing
+from datetime import datetime, timezone
+from typing import Any
+
+ALLOWED_BACKEND_MODES = {"vereinsflieger", "local_db"}
+DEFAULT_BACKEND_MODE = "vereinsflieger"
+
+_BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+_DB_PATH = os.getenv("ORDER_DB_PATH", os.path.join(_BASE_DIR, "data", "orders.db"))
+
+
+def _get_connection() -> sqlite3.Connection:
+    """Create a sqlite3 connection with row factory enabled."""
+    os.makedirs(os.path.dirname(_DB_PATH), exist_ok=True)
+    conn = sqlite3.connect(_DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db() -> None:
+    """Create required settings and orders tables if they do not yet exist."""
+    with closing(_get_connection()) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS settings (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL,
+                updated_at_utc TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS orders (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                created_at_utc TEXT NOT NULL,
+                source TEXT NOT NULL,
+                memberid TEXT NOT NULL,
+                itemid TEXT NOT NULL,
+                articleid TEXT,
+                amount INTEGER NOT NULL,
+                bookingdate TEXT NOT NULL,
+                vf_response_json TEXT
+            )
+            """
+        )
+        conn.commit()
+
+
+def _utc_now_iso() -> str:
+    """Return current UTC timestamp in ISO-8601 format."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def get_sales_backend_mode() -> str:
+    """Return currently configured sales backend mode."""
+    init_db()
+    with closing(_get_connection()) as conn:
+        row = conn.execute("SELECT value FROM settings WHERE key = ?", ("sales_backend_mode",)).fetchone()
+        if row and row["value"] in ALLOWED_BACKEND_MODES:
+            return row["value"]
+
+    env_mode = os.getenv("SALES_BACKEND_MODE", DEFAULT_BACKEND_MODE).strip().lower()
+    if env_mode not in ALLOWED_BACKEND_MODES:
+        env_mode = DEFAULT_BACKEND_MODE
+    set_sales_backend_mode(env_mode)
+    return env_mode
+
+
+def set_sales_backend_mode(mode: str) -> str:
+    """Persist and return sales backend mode."""
+    normalized = (mode or "").strip().lower()
+    if normalized not in ALLOWED_BACKEND_MODES:
+        allowed = ", ".join(sorted(ALLOWED_BACKEND_MODES))
+        raise ValueError(f"Invalid mode '{mode}'. Allowed values: {allowed}")
+
+    init_db()
+    with closing(_get_connection()) as conn:
+        conn.execute(
+            """
+            INSERT INTO settings(key, value, updated_at_utc)
+            VALUES(?, ?, ?)
+            ON CONFLICT(key)
+            DO UPDATE SET value = excluded.value, updated_at_utc = excluded.updated_at_utc
+            """,
+            ("sales_backend_mode", normalized, _utc_now_iso()),
+        )
+        conn.commit()
+    return normalized
+
+
+def record_order(
+    *,
+    source: str,
+    memberid: str,
+    itemid: str,
+    articleid: str | None,
+    amount: int,
+    bookingdate: str,
+    vf_response: dict[str, Any] | None,
+) -> int:
+    """Insert one order row and return its generated database id."""
+    init_db()
+    with closing(_get_connection()) as conn:
+        cursor = conn.execute(
+            """
+            INSERT INTO orders(
+                created_at_utc, source, memberid, itemid, articleid, amount, bookingdate, vf_response_json
+            )
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                _utc_now_iso(),
+                source,
+                str(memberid),
+                str(itemid),
+                articleid,
+                int(amount),
+                bookingdate,
+                json.dumps(vf_response, ensure_ascii=False) if vf_response is not None else None,
+            ),
+        )
+        conn.commit()
+        return int(cursor.lastrowid)
+
+
+def list_orders(*, from_date: str | None = None, to_date: str | None = None, memberid: str | None = None) -> list[dict[str, Any]]:
+    """Return persisted orders with optional booking-date/member filter."""
+    init_db()
+    where: list[str] = []
+    params: list[Any] = []
+
+    if from_date:
+        where.append("bookingdate >= ?")
+        params.append(from_date)
+    if to_date:
+        where.append("bookingdate <= ?")
+        params.append(to_date)
+    if memberid:
+        where.append("memberid = ?")
+        params.append(str(memberid))
+
+    query = "SELECT * FROM orders"
+    if where:
+        query += " WHERE " + " AND ".join(where)
+    query += " ORDER BY id DESC"
+
+    with closing(_get_connection()) as conn:
+        rows = conn.execute(query, tuple(params)).fetchall()
+    return [dict(row) for row in rows]
+
+
+def orders_to_csv(orders: list[dict[str, Any]]) -> str:
+    """Serialize order rows to CSV text."""
+    buffer = io.StringIO()
+    fieldnames = [
+        "id",
+        "created_at_utc",
+        "source",
+        "memberid",
+        "itemid",
+        "articleid",
+        "amount",
+        "bookingdate",
+        "vf_response_json",
+    ]
+    writer = csv.DictWriter(buffer, fieldnames=fieldnames)
+    writer.writeheader()
+    for order in orders:
+        writer.writerow({name: order.get(name) for name in fieldnames})
+    return buffer.getvalue()

--- a/broker/vf_data.py
+++ b/broker/vf_data.py
@@ -6,12 +6,18 @@ import os
 import requests
 import hashlib
 import logging
+try:
+    from . import orders_db
+except ImportError:  # pragma: no cover - fallback for script execution
+    import orders_db
 
 CACHE_FILE = "data/shop_items_cache.json"
 CACHE_TTL = 86400  # Cache validity in seconds
 CON_ERROR = "Connection error"
+REQUEST_TIMEOUT_SECONDS = 10
 
 def get_shop_items_cached():
+    """Return shop items from file cache when valid, otherwise refresh from API."""
     # Check if cache file exists and is still valid
     if os.path.exists(CACHE_FILE):
         with open(CACHE_FILE, "r") as f:
@@ -51,7 +57,8 @@ def get_access_token():
         str: The access token if the request is successful.
         """
     url = _api_url + "interface/rest/auth/accesstoken"
-    response = requests.get(url)
+    response = requests.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
+    response.raise_for_status()
     data = response.json()
     return data.get("accesstoken")
 
@@ -61,10 +68,6 @@ _api_username = os.environ.get("API_USERNAME")
 _api_password = os.environ.get("API_PASSWORD")
 _api_url = os.environ.get("API_URL")
 _api_cid = os.environ.get("API_CID")
-
-
-def test():
-    print(_api_token)
 
 
 def login():
@@ -100,11 +103,8 @@ def login():
         "cid": _api_cid,
         #"auth_secret": auth_secret
     }
-    logging.debug('Password: ')
-    logging.debug(password)
     logging.debug('Accesstoken: ' + str(accesstoken))
-    logging.debug(json.dumps(payload, indent=4))
-    response = requests.post(url, data=json.dumps(payload))
+    response = requests.post(url, data=json.dumps(payload), timeout=REQUEST_TIMEOUT_SECONDS)
     logging.debug(response.text)
     if response.status_code == 200:
         return accesstoken
@@ -135,7 +135,7 @@ def get_vfid(vname, nname):
         payload = {
             'accesstoken': accesstoken,
         }
-        response = requests.post(url, data=json.dumps(payload))
+        response = requests.post(url, data=json.dumps(payload), timeout=REQUEST_TIMEOUT_SECONDS)
         logging.debug(json.dumps(response.json(), indent=4))
         if response.status_code != 200:
             raise ConnectionError("Server returned " + str(response.status_code))
@@ -191,7 +191,7 @@ def get_shop_items():
         payload = {
             'accesstoken': accesstoken,
         }
-        response = requests.post(url, data=json.dumps(payload))
+        response = requests.post(url, data=json.dumps(payload), timeout=REQUEST_TIMEOUT_SECONDS)
         if response.status_code != 200:
             raise ConnectionError("Server returned " + str(response.status_code))
         else:
@@ -201,6 +201,7 @@ def get_shop_items():
         return CON_ERROR
 
 def get_fu_products():
+    """Return products where articleid starts with 'Snackautomat Reihe '."""
     articles = get_shop_items_cached()
     prefix="Snackautomat Reihe "
     filtered_articles = {
@@ -292,6 +293,7 @@ def get_valid_fu_products():
 
 
 def set_new_sale(buyer, amount, item):
+    """Create a sale booking for a buyer and an item."""
     url = _api_url + "interface/rest/sale/add"
     logging.info('setting shop buy...')
     try:
@@ -305,7 +307,7 @@ def set_new_sale(buyer, amount, item):
             'comment': "Automatisch gebucht",
         }
         logging.debug(json.dumps(payload, indent=4))
-        response = requests.post(url, data=json.dumps(payload))
+        response = requests.post(url, data=json.dumps(payload), timeout=REQUEST_TIMEOUT_SECONDS)
         if response.status_code != 200:
             raise ConnectionError("Server returned " + str(response.status_code))
         else:
@@ -315,7 +317,83 @@ def set_new_sale(buyer, amount, item):
         return CON_ERROR
 
 
+def get_sales_backend_mode() -> str:
+    """Return configured sales backend mode ('vereinsflieger' or 'local_db')."""
+    return orders_db.get_sales_backend_mode()
+
+
+def set_sales_backend_mode(mode: str) -> str:
+    """Persist sales backend mode and return normalized value."""
+    return orders_db.set_sales_backend_mode(mode)
+
+
+def export_orders(*, output_format: str, from_date: str | None = None, to_date: str | None = None, memberid: str | None = None):
+    """
+    Export locally persisted machine orders as JSON or CSV.
+
+    Returns:
+        tuple: (content, mimetype)
+    """
+    orders = orders_db.list_orders(from_date=from_date, to_date=to_date, memberid=memberid)
+    if output_format == "json":
+        return json.dumps(orders, ensure_ascii=False), "application/json"
+    if output_format == "csv":
+        return orders_db.orders_to_csv(orders), "text/csv"
+    raise ValueError("output_format must be 'json' or 'csv'")
+
+
+def process_sale(buyer, amount, item):
+    """
+    Process one machine sale according to configured backend mode.
+
+    In `vereinsflieger` mode a real Vereinsflieger booking is executed.
+    In `local_db` mode the order is only persisted locally.
+    """
+    mode = get_sales_backend_mode()
+    normalized_amount = int(amount)
+    memberid = str(buyer["memberid"])
+    itemid = str(item.get("id", item.get("articleid", "")))
+    articleid = str(item.get("articleid", ""))
+    bookingdate = datetime.now().date().isoformat()
+
+    if mode == "vereinsflieger":
+        response = set_new_sale(buyer=buyer, amount=normalized_amount, item=item)
+        if response == CON_ERROR:
+            return response
+        orders_db.record_order(
+            source="vereinsflieger",
+            memberid=memberid,
+            itemid=itemid,
+            articleid=articleid,
+            amount=normalized_amount,
+            bookingdate=bookingdate,
+            vf_response=response if isinstance(response, dict) else {"response": response},
+        )
+        return response
+
+    local_response = {
+        "status": "stored_locally",
+        "memberid": memberid,
+        "itemid": itemid,
+        "articleid": articleid,
+        "amount": normalized_amount,
+        "bookingdate": bookingdate,
+    }
+    order_id = orders_db.record_order(
+        source="local_db",
+        memberid=memberid,
+        itemid=itemid,
+        articleid=articleid,
+        amount=normalized_amount,
+        bookingdate=bookingdate,
+        vf_response=None,
+    )
+    local_response["order_id"] = order_id
+    return local_response
+
+
 def get_user_info(keyname):
+    """Return a user matching RFID keyname from local token file."""
     with open('data/token.json', 'r') as file:
         users = json.load(file)
     for user in users:

--- a/local/backend/ADMIN_MODE_CLIENT.md
+++ b/local/backend/ADMIN_MODE_CLIENT.md
@@ -1,0 +1,16 @@
+# Admin-Modus & Export im lokalen Frontend
+
+## Admin API (lokaler Service)
+- `GET /admin/sales_backend_mode`
+- `PUT /admin/sales_backend_mode` mit `{ "mode": "vereinsflieger" | "local_db" }`
+- `GET /orders/export?...` (Proxy auf Broker)
+
+## Tkinter Frontend
+Das Frontend enthält ein **Admin-Fenster** mit:
+- Anzeige des aktiven Modus
+- Umschalten zwischen `vereinsflieger` und `local_db`
+- Export von Bestellungen als JSON oder CSV
+- optionalen Filtern (`from`, `to`, `memberid`)
+
+## Hinweis
+Der lokale Service agiert als Proxy, damit das Frontend nur einen Host kennen muss.

--- a/local/backend/api_caller.py
+++ b/local/backend/api_caller.py
@@ -10,8 +10,10 @@ load_dotenv()
 
 # Check if self-signed certificates should be ignored
 ignore_self_signed_cert = os.getenv('IGNORE_SELF_SIGNED_CERT', 'false').lower() == 'true'
+REQUEST_TIMEOUT_SECONDS = 10
 
 def get_jwt_token(payload) -> str:
+    """Create a signed JWT used for broker authentication."""
     key = os.environ.get('JWT_SECRET_KEY')
     if not isinstance(key, str):
         raise TypeError("JWT_SECRET_KEY environment variable must be a string")
@@ -20,60 +22,153 @@ def get_jwt_token(payload) -> str:
     return token
 
 def get_user_by_rfid(rfid: str) -> dict:
+    """Fetch user information associated with an RFID token."""
     payload = {
         "sub": "get_user_by_rfid",
         "name": "Frontend",
         "iat": datetime.datetime.utcnow()
     }
     headers = {"Authorization": f"Bearer {get_jwt_token(payload)}"}
-    response = requests.post(f"{os.environ.get('backendip')}/getUserInfo", json={"rfid_id": rfid}, headers=headers, verify=not ignore_self_signed_cert)
+    response = requests.post(
+        f"{os.environ.get('backendip')}/getUserInfo",
+        json={"rfid_id": rfid},
+        headers=headers,
+        verify=not ignore_self_signed_cert,
+        timeout=REQUEST_TIMEOUT_SECONDS
+    )
     response.raise_for_status()
     return response.json()
 
 def get_valid_products() -> dict:
+    """Fetch products that are currently valid for sale."""
     payload = {
         "sub": "get_valid_products",
         "name": "Frontend",
         "iat": datetime.datetime.utcnow()
     }
     headers = {"Authorization": f"Bearer {get_jwt_token(payload)}"}
-    response = requests.get(f"{os.environ.get('backendip')}/getValidFUProducts", headers=headers, verify=not ignore_self_signed_cert)
+    response = requests.get(
+        f"{os.environ.get('backendip')}/getValidFUProducts",
+        headers=headers,
+        verify=not ignore_self_signed_cert,
+        timeout=REQUEST_TIMEOUT_SECONDS
+    )
     response.raise_for_status()
     return response.json()
 
 def get_product(row: str):
+    """Fetch product metadata for one vending row."""
     payload = {
         "sub": "get_product",
         "name": "Frontend",
         "iat": datetime.datetime.utcnow()
     }
     headers = {"Authorization": f"Bearer {get_jwt_token(payload)}"}
-    response = requests.post(f"{os.environ.get('backendip')}/getSpecificProduct", json={"row": row}, headers=headers, verify=not ignore_self_signed_cert)
+    response = requests.post(
+        f"{os.environ.get('backendip')}/getSpecificProduct",
+        json={"row": row},
+        headers=headers,
+        verify=not ignore_self_signed_cert,
+        timeout=REQUEST_TIMEOUT_SECONDS
+    )
     response.raise_for_status()
     return response
 
 def set_new_sale(memberid: str, itemid: str, amount: int) -> dict:
+    """Create a sale in broker backend for the selected product."""
     payload = {
         "sub": "set_new_sale",
         "name": "Frontend",
         "iat": datetime.datetime.utcnow()
     }
     headers = {"Authorization": f"Bearer {get_jwt_token(payload)}"}
-    response = requests.post(f"{os.environ.get('backendip')}/Buy", json={"memberid": memberid, "itemid": itemid, "amount": amount}, headers=headers, verify=not ignore_self_signed_cert)
+    response = requests.post(
+        f"{os.environ.get('backendip')}/Buy",
+        json={"memberid": memberid, "itemid": itemid, "amount": amount},
+        headers=headers,
+        verify=not ignore_self_signed_cert,
+        timeout=REQUEST_TIMEOUT_SECONDS
+    )
     response.raise_for_status()
     return response.json()
 
 
+def get_sales_backend_mode() -> dict:
+    """Fetch active sales backend mode from broker admin endpoint."""
+    payload = {
+        "sub": "get_sales_backend_mode",
+        "name": "Frontend",
+        "iat": datetime.datetime.utcnow()
+    }
+    headers = {"Authorization": f"Bearer {get_jwt_token(payload)}"}
+    response = requests.get(
+        f"{os.environ.get('backendip')}/admin/sales-backend-mode",
+        headers=headers,
+        verify=not ignore_self_signed_cert,
+        timeout=REQUEST_TIMEOUT_SECONDS
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def set_sales_backend_mode(mode: str) -> dict:
+    """Set sales backend mode on broker admin endpoint."""
+    payload = {
+        "sub": "set_sales_backend_mode",
+        "name": "Frontend",
+        "iat": datetime.datetime.utcnow()
+    }
+    headers = {"Authorization": f"Bearer {get_jwt_token(payload)}"}
+    response = requests.put(
+        f"{os.environ.get('backendip')}/admin/sales-backend-mode",
+        json={"mode": mode},
+        headers=headers,
+        verify=not ignore_self_signed_cert,
+        timeout=REQUEST_TIMEOUT_SECONDS
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def export_orders(output_format: str = "json", from_date: str | None = None, to_date: str | None = None, memberid: str | None = None):
+    """Request order export from broker and return raw response object."""
+    payload = {
+        "sub": "export_orders",
+        "name": "Frontend",
+        "iat": datetime.datetime.utcnow()
+    }
+    headers = {"Authorization": f"Bearer {get_jwt_token(payload)}"}
+    params = {"format": output_format}
+    if from_date:
+        params["from"] = from_date
+    if to_date:
+        params["to"] = to_date
+    if memberid:
+        params["memberid"] = memberid
+    response = requests.get(
+        f"{os.environ.get('backendip')}/export/orders",
+        params=params,
+        headers=headers,
+        verify=not ignore_self_signed_cert,
+        timeout=REQUEST_TIMEOUT_SECONDS
+    )
+    response.raise_for_status()
+    return response
+
+
 def test_connection():
-            payload = {
-                "sub": "test_connection",
-                "name": "Frontend",
-                "iat": datetime.datetime.utcnow()
-            }
-            headers = {"Authorization": f"Bearer {get_jwt_token(payload)}"}
-            response = requests.get(f"{os.environ.get('backendip')}/test", headers=headers, verify=False)
-            response.raise_for_status()
-            if response.text == "Hello World":
-                return True
-            else:
-                return False
+    """Test whether the broker endpoint is reachable and authenticated."""
+    payload = {
+        "sub": "test_connection",
+        "name": "Frontend",
+        "iat": datetime.datetime.utcnow()
+    }
+    headers = {"Authorization": f"Bearer {get_jwt_token(payload)}"}
+    response = requests.get(
+        f"{os.environ.get('backendip')}/test",
+        headers=headers,
+        verify=not ignore_self_signed_cert,
+        timeout=REQUEST_TIMEOUT_SECONDS
+    )
+    response.raise_for_status()
+    return response.text == "Hello World"

--- a/local/backend/frontend.py
+++ b/local/backend/frontend.py
@@ -1,6 +1,8 @@
 import logging
 import tkinter as tk
+from tkinter import filedialog, messagebox
 from threading import Thread
+from datetime import datetime
 
 
 from api_caller import get_user_by_rfid  # Import the API caller method
@@ -12,6 +14,7 @@ import traceback
 selected_rows = {f"Row {i}": False for i in range(1, 13)}  # 12 rows
 
 def handle_button_click(row):
+    """Handle row selection and dispatch worker execution in background."""
     if not selected_rows[row]:  # Execute if the row has not been processed
         status_label.config(text=f"Processing {row}...")  # Update status
         selected_rows[row] = True  # Mark the row as selected
@@ -21,6 +24,7 @@ def handle_button_click(row):
         worker_thread.start()
 
 def worker_run_wrapper(row):
+    """Execute worker action and update UI status safely afterwards."""
     try:
         run(row)  # Call the worker function
     except Exception as e:
@@ -30,6 +34,7 @@ def worker_run_wrapper(row):
         root.after(0, lambda: status_label.config(text=f"{row} has been processed successfully."))
 
 def create_interface(firstname, lastname):
+    """Render fullscreen vending UI for authenticated user."""
     global root, status_label
 
     # Create the main Tkinter window
@@ -70,6 +75,9 @@ def create_interface(firstname, lastname):
     exit_button = tk.Button(root, text="Exit", font=("Arial", 14), bg="lightgray", command=exit_to_login)
     exit_button.pack(pady=20)
 
+    admin_button = tk.Button(root, text="Admin", font=("Arial", 14), bg="lightyellow", command=open_admin_window)
+    admin_button.pack(pady=10)
+
     # Status label
     status_label = tk.Label(root, text="Select a row to activate.", font=("Arial", 12))
     status_label.pack(pady=20)
@@ -77,10 +85,93 @@ def create_interface(firstname, lastname):
     # Start the Tkinter main loop
     root.mainloop()
 def exit_to_login():
+    """Close current interface and return to login screen."""
     root.destroy()  # Destroy the main window
     login()  # Open the login window again
 
+
+def open_admin_window():
+    """Open admin controls for backend mode switching and order export."""
+    admin_window = tk.Toplevel(root)
+    admin_window.title("Admin")
+    admin_window.geometry("700x400")
+
+    mode_var = tk.StringVar(value="Unbekannt")
+
+    def refresh_mode():
+        try:
+            mode_response = api_caller.get_sales_backend_mode()
+            mode_var.set(mode_response.get("mode", "Unbekannt"))
+        except Exception as exc:
+            mode_var.set("Fehler")
+            messagebox.showerror("Fehler", f"Modus konnte nicht geladen werden: {exc}")
+
+    def set_mode(mode: str):
+        try:
+            api_caller.set_sales_backend_mode(mode)
+            refresh_mode()
+            messagebox.showinfo("Erfolg", f"Modus wurde auf '{mode}' gesetzt.")
+        except Exception as exc:
+            messagebox.showerror("Fehler", f"Modus konnte nicht gesetzt werden: {exc}")
+
+    def export_orders(output_format: str):
+        from_date = from_entry.get().strip() or None
+        to_date = to_entry.get().strip() or None
+        memberid = memberid_entry.get().strip() or None
+        now_stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        ext = "csv" if output_format == "csv" else "json"
+        file_path = filedialog.asksaveasfilename(
+            title="Bestellungen exportieren",
+            defaultextension=f".{ext}",
+            filetypes=[(ext.upper(), f"*.{ext}"), ("All files", "*.*")],
+            initialfile=f"orders_export_{now_stamp}.{ext}",
+        )
+        if not file_path:
+            return
+        try:
+            response = api_caller.export_orders(
+                output_format=output_format,
+                from_date=from_date,
+                to_date=to_date,
+                memberid=memberid,
+            )
+            with open(file_path, "wb") as export_file:
+                export_file.write(response.content)
+            messagebox.showinfo("Erfolg", f"Export gespeichert: {file_path}")
+        except Exception as exc:
+            messagebox.showerror("Fehler", f"Export fehlgeschlagen: {exc}")
+
+    tk.Label(admin_window, text="Sales Backend Modus", font=("Arial", 14, "bold")).pack(pady=10)
+    tk.Label(admin_window, textvariable=mode_var, font=("Arial", 13)).pack(pady=5)
+
+    mode_button_frame = tk.Frame(admin_window)
+    mode_button_frame.pack(pady=8)
+    tk.Button(mode_button_frame, text="Vereinsflieger", command=lambda: set_mode("vereinsflieger"), width=16).pack(side="left", padx=6)
+    tk.Button(mode_button_frame, text="Local DB", command=lambda: set_mode("local_db"), width=16).pack(side="left", padx=6)
+    tk.Button(mode_button_frame, text="Aktualisieren", command=refresh_mode, width=16).pack(side="left", padx=6)
+
+    tk.Label(admin_window, text="Order Export Filter", font=("Arial", 14, "bold")).pack(pady=12)
+    filter_frame = tk.Frame(admin_window)
+    filter_frame.pack(pady=6)
+    tk.Label(filter_frame, text="Von (YYYY-MM-DD)").grid(row=0, column=0, sticky="w")
+    from_entry = tk.Entry(filter_frame, width=20)
+    from_entry.grid(row=0, column=1, padx=5)
+    tk.Label(filter_frame, text="Bis (YYYY-MM-DD)").grid(row=1, column=0, sticky="w")
+    to_entry = tk.Entry(filter_frame, width=20)
+    to_entry.grid(row=1, column=1, padx=5)
+    tk.Label(filter_frame, text="Member ID").grid(row=2, column=0, sticky="w")
+    memberid_entry = tk.Entry(filter_frame, width=20)
+    memberid_entry.grid(row=2, column=1, padx=5)
+
+    export_button_frame = tk.Frame(admin_window)
+    export_button_frame.pack(pady=12)
+    tk.Button(export_button_frame, text="Export JSON", width=16, command=lambda: export_orders("json")).pack(side="left", padx=8)
+    tk.Button(export_button_frame, text="Export CSV", width=16, command=lambda: export_orders("csv")).pack(side="left", padx=8)
+
+    refresh_mode()
+
 def login():
+    """Render login screen and start RFID-based authentication flow."""
     def attempt_login():
         rfid = rfid_entry.get()
         rfid = str(rfid)

--- a/local/backend/local_api.py
+++ b/local/backend/local_api.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, abort, Response
 from flask_cors import CORS
 import worker
 import flask
@@ -14,11 +14,14 @@ load_dotenv()
 
 @app.route('/buy', methods=['POST'])
 def run_worker():
-    data = flask.request.get_json()
+    """Run one vending turn and book the resulting sale in the broker."""
+    data = flask.request.get_json(silent=True) or {}
     row = data.get('row')
     memberid = data.get('memberid')
+    if not isinstance(row, (str, int)):
+        return {"error": "row must be a string or integer"}, 400
     try:
-        if worker.run(row) is True: # Call the worker function
+        if worker.run(str(row)) is True: # Call the worker function
             api_caller.set_new_sale(memberid=memberid, itemid=row, amount=1)
             return {"message": f"{row} processed successfully"}, 200
         else:
@@ -38,6 +41,7 @@ def run_worker():
 
 @app.route('/get_product_list', methods=['GET'])
 def get_products():
+    """Fetch currently valid products from broker service."""
     try:
         products = api_caller.get_valid_products()
         return products, 200
@@ -48,6 +52,7 @@ def get_products():
 
 @app.route('/get_user_info', methods=['GET'])
 def login():
+    """Read NFC and return matching user data from broker service."""
     nfc_id = read_nfc.read_uid()
     if nfc_id:
         rfid = nfc_id.upper()
@@ -57,13 +62,14 @@ def login():
             return user_info, 200
         except Exception as e:
             logging.debug(f"Error getting user info for RFID {rfid}: {e}")
-            return {f'error": User  for RFID {rfid} not found'}, 500
+            return {"error": f"User for RFID {rfid} not found"}, 500
     else:
         return jsonify({"error": "Failed to read NFC tag"}), 500
 
 
 @app.route('/health', methods=['GET'])
 def health_check():
+    """Basic readiness check for environment and broker connectivity."""
     if os.getenv('FLASK_ENV') not in ['production', 'development']:
         return {"status": "error", "message": "FLASK_ENV not set correctly"}, 500
     if api_caller.test_connection() is False:
@@ -73,22 +79,23 @@ def health_check():
 
 @app.route("/wifi/list", methods=['GET'])
 def api_wifi_list():
+    """List Wi-Fi networks via NetworkManager with optional filtering."""
     refresh = request.args.get("refresh") in {"1", "true", "yes"}
     min_signal = request.args.get("min_signal", type=int)
     limit = request.args.get("limit", type=int)
 
     try:
         networks = wifi_manager.list_wifi()
-    except ConnectionError as e:
-        os.abort(503, description=str(e))
+    except wifi_manager.WifiError as e:
+        abort(503, description=str(e))
 
     if refresh:
         # aktiven Rescan triggern und erneut lesen
         from wifi_manager import run
         try:
             iface = wifi_manager.detect_wifi_iface()
-            run(f"nmcli device wifi rescan ifname {iface}")
-            networks = wifi_manager.detect_wifi_iface(iface)
+            run(["nmcli", "device", "wifi", "rescan", "ifname", iface])
+            networks = wifi_manager.list_wifi(iface=iface)
         except Exception:
             pass
 
@@ -121,18 +128,18 @@ def api_wifi_connect():
     hidden = bool(data.get("hidden", False))
 
     if not isinstance(ssid, str) or not ssid.strip():
-        os.abort(400, description="ssid fehlt oder ist leer")
+        abort(400, description="ssid fehlt oder ist leer")
     if not isinstance(password, str) or not password:
-        os.abort(400, description="password fehlt oder ist leer")
+        abort(400, description="password fehlt oder ist leer")
     if bssid is not None and not isinstance(bssid, str):
-        os.abort(400, description="bssid muss String sein")
+        abort(400, description="bssid muss String sein")
     if iface is not None and not isinstance(iface, str):
-        os.abort(400, description="iface muss String sein")
+        abort(400, description="iface muss String sein")
 
     try:
         used_iface = wifi_manager.wifi_connect(ssid=ssid.strip(), password=password, iface=iface, bssid=bssid, hidden=hidden)
-    except ConnectionError as e:
-        os.abort(502, description=str(e))
+    except wifi_manager.WifiError as e:
+        abort(502, description=str(e))
 
     return jsonify({
         "status": "connected",
@@ -144,15 +151,60 @@ def api_wifi_connect():
 
 @app.route("/ota", methods=['GET'])
 def ota_update():
+    """Placeholder route until OTA update flow is implemented."""
+    return {"status": "not_implemented", "message": "OTA update is not implemented yet"}, 501
+
+
+@app.route("/admin/sales_backend_mode", methods=["GET"])
+def get_sales_backend_mode():
+    """Expose current broker sales backend mode for admin frontend."""
     try:
-        #TODO: Implement OTA update logic
-        if worker is True:
-            return {"message": "OTA update successful"}, 200
-        else:
-            return {"message": "OTA update failed"}, 500
-    except Exception as e:
-        logging.debug(f"Error during OTA update: {e}")
-        return {"error": str(e)}, 500
+        return api_caller.get_sales_backend_mode(), 200
+    except Exception as exc:
+        return {"error": str(exc)}, 502
+
+
+@app.route("/admin/sales_backend_mode", methods=["PUT"])
+def set_sales_backend_mode():
+    """Update broker sales backend mode from admin frontend."""
+    data = request.get_json(silent=True) or {}
+    mode = data.get("mode")
+    if not isinstance(mode, str):
+        return {"error": "mode fehlt oder ist ungültig"}, 400
+    try:
+        return api_caller.set_sales_backend_mode(mode=mode), 200
+    except Exception as exc:
+        return {"error": str(exc)}, 502
+
+
+@app.route("/orders/export", methods=["GET"])
+def export_orders():
+    """Proxy order export from broker to local web interface clients."""
+    output_format = request.args.get("format", default="json", type=str)
+    from_date = request.args.get("from", type=str)
+    to_date = request.args.get("to", type=str)
+    memberid = request.args.get("memberid", type=str)
+    try:
+        response = api_caller.export_orders(
+            output_format=output_format,
+            from_date=from_date,
+            to_date=to_date,
+            memberid=memberid,
+        )
+    except Exception as exc:
+        return {"error": str(exc)}, 502
+
+    headers = {}
+    content_disposition = response.headers.get("Content-Disposition")
+    if content_disposition:
+        headers["Content-Disposition"] = content_disposition
+
+    return Response(
+        response.content,
+        status=response.status_code,
+        mimetype=response.headers.get("Content-Type", "application/octet-stream"),
+        headers=headers,
+    )
 
 
 if __name__ == '__main__':
@@ -164,4 +216,4 @@ if __name__ == '__main__':
         logging.basicConfig(level=logging.DEBUG)
     else:
         raise AttributeError("FLASK_ENV environment variable not set to 'production' or 'development'")
-    app.run(debug=True, host="0.0.0.0", port=8124)
+    app.run(debug=app.config['DEBUG'], host="0.0.0.0", port=8124)

--- a/local/backend/read_nfc.py
+++ b/local/backend/read_nfc.py
@@ -1,12 +1,12 @@
 import subprocess
 
 def read_uid():
-    cmd = "nfc-poll | awk '/UID/ {print $3$4$5$6$7$8$9; exit}'"
-    result = subprocess.run(
-        cmd,
-        shell=True,
-        capture_output=True,
-        text=True
-    )
-    uid = result.stdout.strip()
-    return uid or None
+    """Read an NFC UID in a shell-safe way from nfc-poll output."""
+    result = subprocess.run(["nfc-poll"], capture_output=True, text=True, check=False)
+    for line in result.stdout.splitlines():
+        if "UID" not in line:
+            continue
+        uid = "".join(part for part in line.split()[1:] if part.isalnum())
+        if uid:
+            return uid
+    return None

--- a/local/backend/wifi_manager.py
+++ b/local/backend/wifi_manager.py
@@ -1,11 +1,12 @@
 import subprocess
-import shlex
 
 class WifiError(RuntimeError):
+    """Raised when a Wi-Fi shell command exits non-zero."""
     pass
 
-def run(cmd: str) -> str:
-    proc = subprocess.run(shlex.split(cmd), text=True, capture_output=True)
+def run(args: list[str]) -> str:
+    """Run a NetworkManager command and return stdout text."""
+    proc = subprocess.run(args, text=True, capture_output=True)
     if proc.returncode != 0:
         raise WifiError((proc.stderr or proc.stdout).strip())
     return proc.stdout.strip()
@@ -16,7 +17,7 @@ def detect_wifi_iface() -> str:
     Präferenz: verbunden > getrennt aber verfügbar.
     """
     # nmcli device status: DEVICE  TYPE  STATE  CONNECTION
-    out = run("nmcli -t -f DEVICE,TYPE,STATE device status")
+    out = run(["nmcli", "-t", "-f", "DEVICE,TYPE,STATE", "device", "status"])
     candidates = []
     for line in out.splitlines():
         parts = line.split(":")
@@ -42,7 +43,7 @@ def list_wifi(iface: str | None = None):
     """
     iface = iface or detect_wifi_iface()
     # -t = tabellarisch, Felder: IN-USE,SSID,BSSID,SIGNAL,SECURITY
-    out = run(f"nmcli -t -f IN-USE,SSID,BSSID,SIGNAL,SECURITY device wifi list ifname {iface}")
+    out = run(["nmcli", "-t", "-f", "IN-USE,SSID,BSSID,SIGNAL,SECURITY", "device", "wifi", "list", "ifname", iface])
     nets = []
     for line in out.splitlines():
         parts = (line.split(":", maxsplit=4) + ["", "", "", "", ""])[:5]
@@ -58,17 +59,25 @@ def list_wifi(iface: str | None = None):
         })
     return nets
 
-def wifi_connect(ssid: str, password: str, iface: str | None = None, bssid: str | None = None):
+def wifi_connect(
+    ssid: str,
+    password: str,
+    iface: str | None = None,
+    bssid: str | None = None,
+    hidden: bool = False
+):
     """
     Verbindet mit SSID. Optional BSSID pinnen.
     Legt das Profil an oder aktualisiert es.
     """
     iface = iface or detect_wifi_iface()
-    args = f'nmcli device wifi connect "{ssid}" password "{password}" ifname {iface}'
+    args = ["nmcli", "device", "wifi", "connect", ssid, "password", password, "ifname", iface]
     if bssid:
-        args += f" bssid {bssid}"
+        args.extend(["bssid", bssid])
+    if hidden:
+        args.extend(["hidden", "yes"])
     run(args)
-    return True
+    return iface
 
 def wifi_forget(ssid: str):
     """
@@ -76,7 +85,7 @@ def wifi_forget(ssid: str):
     Ignoriert, falls nicht vorhanden.
     """
     try:
-        run(f'nmcli connection delete "{ssid}"')
+        run(["nmcli", "connection", "delete", ssid])
     except WifiError as e:
         msg = str(e).lower()
         if "unknown connection" in msg or "not found" in msg:


### PR DESCRIPTION
### Motivation
- Provide a local SQLite-backed order history and the ability to run the vending flow without calling the remote Vereinsflieger API.
- Allow admins to switch between `vereinsflieger` and `local_db` booking modes and to export machine orders as JSON or CSV.
- Harden network calls and local services with timeouts and improved error handling for more reliable embedded operation.

### Description
- Add a new persistence module `orders_db.py` to initialize DB schema, record/list orders, manage `sales_backend_mode`, and serialize CSV exports, and add documentation files `ORDER_EXPORT.md` and `SALES_BACKEND_MODE.md`.
- Integrate persistence and mode logic into `vf_data.py` with `process_sale`, `export_orders`, `get_sales_backend_mode`/`set_sales_backend_mode`, request timeouts, and use of the new `orders_db` APIs.
- Extend broker `main.py` with admin endpoints `GET/PUT /admin/sales-backend-mode`, `GET /export/orders`, improved input validation on `Buy`, `getUserInfo`, `getSpecificProduct`, and switch to environment-based dev check for `FLASK_ENV`.
- Enhance local frontend and backend: add admin UI in `local/backend/frontend.py` for switching mode and exporting orders; update `local/backend/api_caller.py` with JWT creation, mode APIs, export proxy, and timeouts; extend `local/backend/local_api.py` to proxy admin and export endpoints and improve Wi‑Fi and OTA endpoints.
- Improve platform helpers: replace shell usage in `read_nfc.py` with safer parsing, refactor `wifi_manager.py` to run argument lists, introduce `WifiError`, and update Wi‑Fi command usage and return values.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef2c8222c48333a814d901ea11ebac)